### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/RemoteBMI.jl/.copier-answers.yml
+++ b/RemoteBMI.jl/.copier-answers.yml
@@ -19,4 +19,4 @@ RunJuliaNightlyOnCI: false
 SimplifiedPRTest: true
 UseCirrusCI: false
 _commit: v0.7.1
-_src_path: https://github.com/abelsiqueira/BestieTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
