### PR TITLE
R: Catch json parse errors

### DIFF
--- a/R/R/route.R
+++ b/R/R/route.R
@@ -25,8 +25,23 @@ last_segment <- function(path) {
 #' }
 #'
 create_route <- function(model) {
+  parse_json_or_problem <- function(request, response) {
+    tryCatch({
+      request$parse(json = reqres::parse_json())
+      return(TRUE)
+    }, error = function(e) {
+      response$status <- if (!is.null(e$status)) as.integer(e$status) else 400L
+      response$type <- "application/json"
+      response$body <- list(title = as.character(e$message))
+      response$format(json = reqres::format_json(auto_unbox = TRUE))
+      return(FALSE)
+    })
+  }
+
   bmi_initialize <- function(request, response, keys, ...) {
-    request$parse(json = reqres::parse_json())
+    if (!parse_json_or_problem(request, response)) {
+      return(FALSE)
+    }
     model$bmi_initialize(request$body$config_file)
     response$status <- 201L
     return(FALSE)
@@ -39,7 +54,9 @@ create_route <- function(model) {
   }
 
   update_until <- function(request, response, keys, ...) {
-    request$parse(json = reqres::parse_json())
+    if (!parse_json_or_problem(request, response)) {
+      return(FALSE)
+    }
     time <- request$body
     model$update_until(time)
     response$status <- 204L
@@ -205,7 +222,9 @@ create_route <- function(model) {
   }
 
   get_value_at_indices <- function(request, response, keys, ...) {
-    request$parse(json = reqres::parse_json())
+    if (!parse_json_or_problem(request, response)) {
+      return(FALSE)
+    }
     response$status <- 200L
     response$type <- "application/json"
     name <- last_segment(request$path)
@@ -233,14 +252,18 @@ create_route <- function(model) {
   }
 
   set_value <- function(request, response, keys, ...) {
-    request$parse(json = reqres::parse_json())
+    if (!parse_json_or_problem(request, response)) {
+      return(FALSE)
+    }
     model$set_value(last_segment(request$path), request$body)
     response$status <- 204L
     return(FALSE)
   }
 
   set_value_at_indices <- function(request, response, keys, ...) {
-    request$parse(json = reqres::parse_json())
+    if (!parse_json_or_problem(request, response)) {
+      return(FALSE)
+    }
     name <- last_segment(request$path)
     model$set_value_at_indices(name, request$body$indices, request$body$values)
     response$status <- 204L

--- a/R/tests/testthat/test-route.R
+++ b/R/tests/testthat/test-route.R
@@ -167,6 +167,22 @@ test_that("/initialize", {
   expect_equal(method_called_with[["bmi_initialize"]], "some_config")
 })
 
+test_that("/initialize, given string", {
+  fake_rook <- fiery::fake_request("/initialize",
+    content = "foobar",
+    method = "post",
+    headers = list("Content_Type" = "application/json")
+  )
+  req <- reqres::Request$new(fake_rook)
+  res <- req$respond()
+  route$dispatch(req)
+  expect_equal(res$status, 400)
+  expected <- list(
+    title = "Error parsing the request body"
+  )
+  expect_equal(res$body, formatter(expected))
+})
+
 test_that("/update", {
   fake_rook <- fiery::fake_request("/update",
     method = "post"
@@ -189,6 +205,22 @@ test_that("/update_until", {
   route$dispatch(req)
   expect_equal(res$status, 204)
   expect_equal(method_called_with[["update_until"]], 113)
+})
+
+test_that("/update_until, given string", {
+  fake_rook <- fiery::fake_request("/update_until",
+    content = "foobar",
+    method = "post",
+    headers = list("Content_Type" = "application/json")
+  )
+  req <- reqres::Request$new(fake_rook)
+  res <- req$respond()
+  route$dispatch(req)
+  expect_equal(res$status, 400)
+  expected <- list(
+    title = "Error parsing the request body"
+  )
+  expect_equal(res$body, formatter(expected))
 })
 
 test_that("/finalize", {
@@ -359,6 +391,22 @@ test_that("/get_value_at_indices", {
   expect_equal(method_called_with[["get_value_at_indices"]], expected)
 })
 
+test_that("/get_value_at_indices, given json string", {
+  fake_rook <- fiery::fake_request("/get_value_at_indices/Q",
+    content = "\"foobar\"",
+    method = "post",
+    headers = list("Content_Type" = "application/json")
+  )
+  req <- reqres::Request$new(fake_rook)
+  res <- req$respond()
+  route$dispatch(req)
+  expect_equal(res$status, 400)
+  expected <- list(
+    title = "Request body must be an array"
+  )
+  expect_equal(res$body, formatter(expected))
+})
+
 test_that("/get_value_at_indices, given string", {
   fake_rook <- fiery::fake_request("/get_value_at_indices/Q",
     content = "foobar",
@@ -370,7 +418,7 @@ test_that("/get_value_at_indices, given string", {
   route$dispatch(req)
   expect_equal(res$status, 400)
   expected <- list(
-    title = "Request body must be an array"
+    title = "Error parsing the request body"
   )
   expect_equal(res$body, formatter(expected))
 })
@@ -421,6 +469,22 @@ test_that("/set_value", {
   expect_equal(method_called_with[["set_value"]], expected)
 })
 
+test_that("/set_value, given string", {
+  fake_rook <- fiery::fake_request("/set_value/Q",
+    content = "foobar",
+    method = "post",
+    headers = list("Content_Type" = "application/json")
+  )
+  req <- reqres::Request$new(fake_rook)
+  res <- req$respond()
+  route$dispatch(req)
+  expect_equal(res$status, 400)
+  expected <- list(
+    title = "Error parsing the request body"
+  )
+  expect_equal(res$body, formatter(expected))
+})
+
 test_that("set_value_at_indices", {
   fake_rook <- fiery::fake_request("/set_value_at_indices/Q",
     content = '{"indices": [1, 2, 3], "values": [1.1, 2.2, 3.3]}',
@@ -433,6 +497,22 @@ test_that("set_value_at_indices", {
   expect_equal(res$status, 204)
   expected <- list(name = "Q", indices = c(1, 2, 3), values = c(1.1, 2.2, 3.3))
   expect_equal(method_called_with[["set_value_at_indices"]], expected)
+})
+
+test_that("/set_value_at_indices, given string", {
+  fake_rook <- fiery::fake_request("/set_value_at_indices/Q",
+    content = "foobar",
+    method = "post",
+    headers = list("Content_Type" = "application/json")
+  )
+  req <- reqres::Request$new(fake_rook)
+  res <- req$respond()
+  route$dispatch(req)
+  expect_equal(res$status, 400)
+  expected <- list(
+    title = "Error parsing the request body"
+  )
+  expect_equal(res$body, formatter(expected))
 })
 
 test_that("/get_grid_rank", {


### PR DESCRIPTION
JSON parser in reqres is more picky causing

```shell
══ Failed tests ════════════════════════════════════════════════════════════════
── Error ('test-route.R:370:3'): /get_value_at_indices, given string ───────────
<reqres_problem/rlang_error/error/condition>
Error in `request$parse(json = reqres::parse_json())`: Error parsing the request body
Caused by error:
! lexical error: invalid string in json text.
                                       foobar 
                     (right here) ------^
Backtrace:
    ▆
 1. └─route$dispatch(req) at test-route.R:370:3
 2.   └─private$dispatch0(...)
 3.     ├─routr:::with_route_ospan(...)
 4.     └─remotebmi (local) handler(...)
 5.       └─request$parse(json = reqres::parse_json())
 6.         └─reqres::abort_status(...)
 7.           └─rlang::cnd_signal(err)

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 110 ]
Error:
! Test failures.
Execution halted
```

This PR catches the json parse error and returns them.